### PR TITLE
add repository to Cargo.toml

### DIFF
--- a/simplex/Cargo.toml
+++ b/simplex/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 categories = ["algorithms", "mathematics"]
 keywords = ["simplex", "linear-programming"]
 license = "EUPL-1.2"
+repository = "https://github.com/aarroyoc/princeps"
 
 [dependencies]
 ndarray = "0.13.1"


### PR DESCRIPTION
so there's a link on crates.io in the next release